### PR TITLE
chore(lint): pin golangci-lint to v1.64.8 in CI + make target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,10 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: latest
+          # Pinned to match the version used in the Makefile's `lint` target
+          # so local and CI lint runs report identical results. Bump both in
+          # the same change.
+          version: v1.64.8
           args: --timeout=5m
 
   test:

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,9 @@ LDFLAGS := -ldflags "-X main.version=$(VERSION) -X main.commit=$(COMMIT) -X main
 # Go settings
 GOBIN ?= $(shell go env GOPATH)/bin
 
+# Pinned tool versions (keep in sync with .github/workflows/ci.yml)
+GOLANGCI_LINT_VERSION ?= v1.64.8
+
 # Default target
 all: build
 
@@ -93,9 +96,16 @@ benchmark:
 	go test -bench=. -benchmem ./...
 
 # Run linter
+# Pins to the same golangci-lint version CI uses; reinstalls if the local
+# binary is missing or on a different version, so `make lint` matches CI.
 lint:
-	@which golangci-lint > /dev/null || (echo "Installing golangci-lint..." && go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest)
-	golangci-lint run
+	@installed=$$($(GOBIN)/golangci-lint version --format=short 2>/dev/null | sed 's/^v//'); \
+	want=$$(echo $(GOLANGCI_LINT_VERSION) | sed 's/^v//'); \
+	if [ "$$installed" != "$$want" ]; then \
+		echo "Installing golangci-lint $(GOLANGCI_LINT_VERSION) (had: $${installed:-missing})..."; \
+		GOBIN=$(GOBIN) go install github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION); \
+	fi
+	$(GOBIN)/golangci-lint run --timeout=5m
 
 # Format code
 fmt:

--- a/internal/systray/cli_uninstall_darwin.go
+++ b/internal/systray/cli_uninstall_darwin.go
@@ -1,0 +1,57 @@
+//go:build darwin
+
+package systray
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/kevinelliott/agentmanager/pkg/platform"
+)
+
+// uninstallCLI removes the CLI binary from the system path.
+//
+// Only invoked by the darwin systray menu; other platforms have no caller and
+// the function is omitted from their builds via the build tag on this file.
+func (a *App) uninstallCLI() bool {
+	targetPath := "/usr/local/bin/agentmgr"
+
+	switch a.platform.ID() {
+	case platform.Darwin, platform.Linux:
+		// Use osascript to run sudo with password prompt
+		script := fmt.Sprintf(`
+do shell script "rm -f '%s'" with administrator privileges
+`, targetPath)
+
+		cmd := exec.Command("osascript", "-e", script)
+		err := cmd.Run()
+		if err != nil {
+			return false
+		}
+
+		// Clear config path
+		a.config.Helper.CLIPath = ""
+		if a.configLoader != nil {
+			_ = a.configLoader.SetAndSave("helper.cli_path", "")
+		}
+		return true
+
+	case platform.Windows:
+		// Try to remove directly on Windows
+		targetPath = filepath.Join(os.Getenv("LOCALAPPDATA"), "agentmgr", "agentmgr.exe")
+		if err := os.Remove(targetPath); err != nil {
+			return false
+		}
+
+		// Clear config path
+		a.config.Helper.CLIPath = ""
+		if a.configLoader != nil {
+			_ = a.configLoader.SetAndSave("helper.cli_path", "")
+		}
+		return true
+	}
+
+	return false
+}

--- a/internal/systray/systray.go
+++ b/internal/systray/systray.go
@@ -1506,48 +1506,6 @@ func (a *App) installCLIToPathWindows(sourcePath, targetPath string) {
 	}
 }
 
-// uninstallCLI removes the CLI binary from the system path.
-func (a *App) uninstallCLI() bool { //nolint:unused // Reserved for future use
-	targetPath := "/usr/local/bin/agentmgr"
-
-	switch a.platform.ID() {
-	case platform.Darwin, platform.Linux:
-		// Use osascript to run sudo with password prompt
-		script := fmt.Sprintf(`
-do shell script "rm -f '%s'" with administrator privileges
-`, targetPath)
-
-		cmd := exec.Command("osascript", "-e", script)
-		err := cmd.Run()
-		if err != nil {
-			return false
-		}
-
-		// Clear config path
-		a.config.Helper.CLIPath = ""
-		if a.configLoader != nil {
-			_ = a.configLoader.SetAndSave("helper.cli_path", "")
-		}
-		return true
-
-	case platform.Windows:
-		// Try to remove directly on Windows
-		targetPath = filepath.Join(os.Getenv("LOCALAPPDATA"), "agentmgr", "agentmgr.exe")
-		if err := os.Remove(targetPath); err != nil {
-			return false
-		}
-
-		// Clear config path
-		a.config.Helper.CLIPath = ""
-		if a.configLoader != nil {
-			_ = a.configLoader.SetAndSave("helper.cli_path", "")
-		}
-		return true
-	}
-
-	return false
-}
-
 // showLinuxSettings shows the settings dialog on Linux.
 func (a *App) showLinuxSettings() {
 	// Try zenity first


### PR DESCRIPTION
## Summary

Prevents the class of failure we hit on PR #16, where CI used `golangci-lint@latest` and picked up rules that `make lint` never flagged locally. Both CI and Makefile now install the exact same version (`v1.64.8`); bumping is a single-line change in two places, kept literal on both sides for discoverability.

## Changes

**CI** (`.github/workflows/ci.yml`): pin `version: v1.64.8` with a comment pointing to the Makefile counterpart.

**Makefile** (`lint` target):
- installs the pinned version into `$(GOBIN)` if missing or mismatched
- normalizes version strings (leading `v` optional) before comparing
- runs the installed binary by absolute `$(GOBIN)/golangci-lint` so `mise`/`asdf` PATH shims don't win
- adds `GOLANGCI_LINT_VERSION` variable at the top

**Systray**: moved darwin-only `uninstallCLI` into a build-tagged file `internal/systray/cli_uninstall_darwin.go`. Removes the stale `//nolint:unused // Reserved for future use` that was only stale on darwin (the caller has `//go:build darwin`, so linux/windows saw the function as genuinely unused). No behavior change.

## Test plan

- [ ] `make lint` on darwin → passes (previously failed on stale nolint)
- [ ] `make lint` on linux → passes (CI verifies)
- [ ] `make lint` with no prior golangci-lint installed → installs v1.64.8 and runs
- [ ] `make lint` with a different version installed → reinstalls v1.64.8

🤖 Generated with [Claude Code](https://claude.com/claude-code)