### PR TITLE
feat(installer): stream subprocess output during install/update with -v

### DIFF
--- a/internal/cli/agent.go
+++ b/internal/cli/agent.go
@@ -20,9 +20,28 @@ import (
 	"github.com/kevinelliott/agentmanager/pkg/config"
 	"github.com/kevinelliott/agentmanager/pkg/detector"
 	"github.com/kevinelliott/agentmanager/pkg/installer"
+	"github.com/kevinelliott/agentmanager/pkg/installer/providers"
 	"github.com/kevinelliott/agentmanager/pkg/platform"
 	"github.com/kevinelliott/agentmanager/pkg/storage"
 )
+
+// verboseInstallOutput returns true when the user has asked for verbose output
+// at the root level. The root PersistentPreRunE flips Logging.Level to "debug"
+// when `-v/--verbose` is passed. We use that as the single source of truth so
+// enabling verbose anywhere in the tree also enables install/update streaming.
+func verboseInstallOutput(cfg *config.Config) bool {
+	return strings.EqualFold(cfg.Logging.Level, "debug")
+}
+
+// withInstallProgress returns ctx annotated with a progress writer if the
+// user has asked for verbose output. The writer target is os.Stderr (so piped
+// stdout captures of structured output remain clean).
+func withInstallProgress(ctx context.Context, cfg *config.Config) context.Context {
+	if !verboseInstallOutput(cfg) {
+		return ctx
+	}
+	return providers.WithProgressWriter(ctx, os.Stderr)
+}
 
 // NewAgentCommand creates the agent management command group.
 func NewAgentCommand(cfg *config.Config) *cobra.Command {
@@ -287,17 +306,34 @@ will be used.`,
 				return fmt.Errorf("installation method %q not available for %q", method, agentID)
 			}
 
-			spinner.UpdateMessage(fmt.Sprintf("Installing %s via %s...", agentDef.Name, method))
-
-			// Create installer and install
+			// Create installer and install. In verbose mode, stop the spinner
+			// and stream the subprocess output directly (spinner ANSI would
+			// otherwise garble the interleaved output).
 			inst := installer.NewManager(plat)
-			result, err := inst.Install(ctx, agentDef, methodDef, force)
+			installCtx := withInstallProgress(ctx, cfg)
+			if verboseInstallOutput(cfg) {
+				spinner.Stop()
+				fmt.Fprintf(os.Stderr, "Installing %s via %s...\n", agentDef.Name, method)
+			} else {
+				spinner.UpdateMessage(fmt.Sprintf("Installing %s via %s...", agentDef.Name, method))
+			}
+
+			result, err := inst.Install(installCtx, agentDef, methodDef, force)
 			if err != nil {
-				spinner.Error(fmt.Sprintf("Failed to install %s", agentDef.Name))
+				if !verboseInstallOutput(cfg) {
+					spinner.Error(fmt.Sprintf("Failed to install %s", agentDef.Name))
+				} else {
+					fmt.Fprintf(os.Stderr, "Failed to install %s\n", agentDef.Name)
+				}
 				return fmt.Errorf("installation failed: %w", err)
 			}
 
-			spinner.Success(fmt.Sprintf("Installed %s %s successfully", agentDef.Name, result.Version.String()))
+			msg := fmt.Sprintf("Installed %s %s successfully", agentDef.Name, result.Version.String())
+			if verboseInstallOutput(cfg) {
+				fmt.Fprintln(os.Stderr, msg)
+			} else {
+				spinner.Success(msg)
+			}
 			return nil
 		},
 	}
@@ -390,7 +426,7 @@ Use --all to update all agents at once.`,
 			}
 
 			if all {
-				return updateAllAgents(ctx, installations, cat, inst, force, dryRun, printer)
+				return updateAllAgents(ctx, cfg, installations, cat, inst, force, dryRun, printer)
 			}
 
 			if len(args) == 0 {
@@ -398,7 +434,7 @@ Use --all to update all agents at once.`,
 				return fmt.Errorf("agent name required (or use --all)")
 			}
 
-			return updateSingleAgent(ctx, args[0], installations, cat, inst, force, dryRun, printer)
+			return updateSingleAgent(ctx, cfg, args[0], installations, cat, inst, force, dryRun, printer)
 		},
 	}
 
@@ -410,8 +446,9 @@ Use --all to update all agents at once.`,
 }
 
 // updateAllAgents handles the --all flag to update all agents with available updates.
-func updateAllAgents(ctx context.Context, installations []*agent.Installation, cat *catalog.Catalog, inst *installer.Manager, force, dryRun bool, printer *output.Printer) error {
+func updateAllAgents(ctx context.Context, cfg *config.Config, installations []*agent.Installation, cat *catalog.Catalog, inst *installer.Manager, force, dryRun bool, printer *output.Printer) error {
 	styles := printer.Styles()
+	verbose := verboseInstallOutput(cfg)
 
 	spinner := output.NewSpinner(
 		output.WithMessage("Checking for updates..."),
@@ -465,26 +502,43 @@ func updateAllAgents(ctx context.Context, installations []*agent.Installation, c
 			continue
 		}
 
-		spinner := output.NewSpinner(
-			output.WithMessage(fmt.Sprintf("Updating %s via %s...", installation.AgentName, installation.Method)),
-			output.WithNoColor(printer.NoColor()),
-		)
-		spinner.Start()
+		updateCtx := withInstallProgress(ctx, cfg)
+		var spinner *output.Spinner
+		if verbose {
+			fmt.Fprintf(os.Stderr, "Updating %s via %s...\n", installation.AgentName, installation.Method)
+		} else {
+			spinner = output.NewSpinner(
+				output.WithMessage(fmt.Sprintf("Updating %s via %s...", installation.AgentName, installation.Method)),
+				output.WithNoColor(printer.NoColor()),
+			)
+			spinner.Start()
+		}
 
-		result, err := inst.Update(ctx, installation, agentDef, methodDef)
+		result, err := inst.Update(updateCtx, installation, agentDef, methodDef)
 		if err != nil {
-			spinner.Error(fmt.Sprintf("Failed to update %s: %v", installation.AgentName, err))
+			msg := fmt.Sprintf("Failed to update %s: %v", installation.AgentName, err)
+			if verbose {
+				fmt.Fprintln(os.Stderr, msg)
+			} else {
+				spinner.Error(msg)
+			}
 			continue
 		}
-		spinner.Success(fmt.Sprintf("Updated %s to %s", installation.AgentName, result.Version.String()))
+		okMsg := fmt.Sprintf("Updated %s to %s", installation.AgentName, result.Version.String())
+		if verbose {
+			fmt.Fprintln(os.Stderr, okMsg)
+		} else {
+			spinner.Success(okMsg)
+		}
 	}
 
 	return nil
 }
 
 // updateSingleAgent handles updating a specific agent by ID.
-func updateSingleAgent(ctx context.Context, agentID string, installations []*agent.Installation, cat *catalog.Catalog, inst *installer.Manager, force, dryRun bool, printer *output.Printer) error {
+func updateSingleAgent(ctx context.Context, cfg *config.Config, agentID string, installations []*agent.Installation, cat *catalog.Catalog, inst *installer.Manager, force, dryRun bool, printer *output.Printer) error {
 	styles := printer.Styles()
+	verbose := verboseInstallOutput(cfg)
 
 	var agentInstallations []*agent.Installation
 	for _, installation := range installations {
@@ -547,19 +601,35 @@ func updateSingleAgent(ctx context.Context, agentID string, installations []*age
 			continue
 		}
 
-		spinner := output.NewSpinner(
-			output.WithMessage(fmt.Sprintf("Updating %s via %s...", installation.AgentName, installation.Method)),
-			output.WithNoColor(printer.NoColor()),
-		)
-		spinner.Start()
+		updateCtx := withInstallProgress(ctx, cfg)
+		var spinner *output.Spinner
+		if verbose {
+			fmt.Fprintf(os.Stderr, "Updating %s via %s...\n", installation.AgentName, installation.Method)
+		} else {
+			spinner = output.NewSpinner(
+				output.WithMessage(fmt.Sprintf("Updating %s via %s...", installation.AgentName, installation.Method)),
+				output.WithNoColor(printer.NoColor()),
+			)
+			spinner.Start()
+		}
 
-		result, err := inst.Update(ctx, installation, agentDef, methodDef)
+		result, err := inst.Update(updateCtx, installation, agentDef, methodDef)
 		if err != nil {
-			spinner.Error(fmt.Sprintf("Failed to update %s via %s: %v", agentDef.Name, installation.Method, err))
+			msg := fmt.Sprintf("Failed to update %s via %s: %v", agentDef.Name, installation.Method, err)
+			if verbose {
+				fmt.Fprintln(os.Stderr, msg)
+			} else {
+				spinner.Error(msg)
+			}
 			lastErr = err
 			continue
 		}
-		spinner.Success(fmt.Sprintf("Updated %s to %s", agentDef.Name, result.Version.String()))
+		okMsg := fmt.Sprintf("Updated %s to %s", agentDef.Name, result.Version.String())
+		if verbose {
+			fmt.Fprintln(os.Stderr, okMsg)
+		} else {
+			spinner.Success(okMsg)
+		}
 	}
 
 	return lastErr

--- a/pkg/installer/providers/brew.go
+++ b/pkg/installer/providers/brew.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os/exec"
 	"strings"
 	"sync"
@@ -85,9 +86,10 @@ func (p *BrewProvider) Install(ctx context.Context, agentDef catalog.AgentDef, m
 	args = append(args, packageName)
 
 	var stdout, stderr bytes.Buffer
+	progress := ProgressWriter(ctx)
 	cmd := exec.CommandContext(ctx, "brew", args...)
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
+	cmd.Stdout = io.MultiWriter(&stdout, progress)
+	cmd.Stderr = io.MultiWriter(&stderr, progress)
 
 	if err := cmd.Run(); err != nil {
 		return nil, fmt.Errorf("brew install failed: %w\n%s%s", err, stderr.String(), FormatInstallError("brew", "install", stderr.String()))
@@ -129,9 +131,10 @@ func (p *BrewProvider) Update(ctx context.Context, inst *agent.Installation, age
 	args = append(args, packageName)
 
 	var stdout, stderr bytes.Buffer
+	progress := ProgressWriter(ctx)
 	cmd := exec.CommandContext(ctx, "brew", args...)
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
+	cmd.Stdout = io.MultiWriter(&stdout, progress)
+	cmd.Stderr = io.MultiWriter(&stderr, progress)
 
 	if err := cmd.Run(); err != nil {
 		// brew upgrade returns error if already up to date

--- a/pkg/installer/providers/native.go
+++ b/pkg/installer/providers/native.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"strings"
@@ -134,15 +135,17 @@ func (p *NativeProvider) Uninstall(ctx context.Context, inst *agent.Installation
 	return nil
 }
 
-// executeCommand runs a shell command.
+// executeCommand runs a shell command, tee-ing output to any progress writer
+// attached to ctx via WithProgressWriter.
 func (p *NativeProvider) executeCommand(ctx context.Context, command string) (string, error) {
 	shell := p.platform.GetShell()
 	shellArg := p.platform.GetShellArg()
 
 	var stdout, stderr bytes.Buffer
+	progress := ProgressWriter(ctx)
 	cmd := exec.CommandContext(ctx, shell, shellArg, command)
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
+	cmd.Stdout = io.MultiWriter(&stdout, progress)
+	cmd.Stderr = io.MultiWriter(&stderr, progress)
 
 	if err := cmd.Run(); err != nil {
 		return "", fmt.Errorf("%w\n%s", err, stderr.String())

--- a/pkg/installer/providers/npm.go
+++ b/pkg/installer/providers/npm.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"os/exec"
 	"strings"
 	"time"
@@ -59,9 +60,10 @@ func (p *NPMProvider) Install(ctx context.Context, agentDef catalog.AgentDef, me
 	args = append(args, packageName)
 
 	var stdout, stderr bytes.Buffer
+	progress := ProgressWriter(ctx)
 	cmd := exec.CommandContext(ctx, "npm", args...)
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
+	cmd.Stdout = io.MultiWriter(&stdout, progress)
+	cmd.Stderr = io.MultiWriter(&stderr, progress)
 
 	if err := cmd.Run(); err != nil {
 		return nil, fmt.Errorf("npm install failed: %w\n%s%s", err, stderr.String(), formatNPMPermissionHint(stderr.String()))
@@ -100,9 +102,10 @@ func (p *NPMProvider) Update(ctx context.Context, inst *agent.Installation, agen
 
 	// Run update command
 	var stdout, stderr bytes.Buffer
+	progress := ProgressWriter(ctx)
 	cmd := exec.CommandContext(ctx, "npm", "update", "-g", packageName)
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
+	cmd.Stdout = io.MultiWriter(&stdout, progress)
+	cmd.Stderr = io.MultiWriter(&stderr, progress)
 
 	if err := cmd.Run(); err != nil {
 		return nil, fmt.Errorf("npm update failed: %w\n%s%s", err, stderr.String(), formatNPMPermissionHint(stderr.String()))

--- a/pkg/installer/providers/pip.go
+++ b/pkg/installer/providers/pip.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"os/exec"
 	"strings"
@@ -59,9 +60,10 @@ func (p *PipProvider) Install(ctx context.Context, agentDef catalog.AgentDef, me
 	}
 
 	var stdout, stderr bytes.Buffer
+	progress := ProgressWriter(ctx)
 	cmd := exec.CommandContext(ctx, manager, args...)
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
+	cmd.Stdout = io.MultiWriter(&stdout, progress)
+	cmd.Stderr = io.MultiWriter(&stderr, progress)
 
 	if err := cmd.Run(); err != nil {
 		return nil, fmt.Errorf("%s install failed: %w\n%s%s", manager, err, stderr.String(), FormatInstallError(manager, "install", stderr.String()))
@@ -96,9 +98,10 @@ func (p *PipProvider) Update(ctx context.Context, inst *agent.Installation, agen
 	fromVersion := inst.InstalledVersion
 
 	var stdout, stderr bytes.Buffer
+	progress := ProgressWriter(ctx)
 	cmd := exec.CommandContext(ctx, manager, args...)
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
+	cmd.Stdout = io.MultiWriter(&stdout, progress)
+	cmd.Stderr = io.MultiWriter(&stderr, progress)
 
 	if err := cmd.Run(); err != nil {
 		return nil, fmt.Errorf("%s update failed: %w\n%s%s", manager, err, stderr.String(), FormatInstallError(manager, "update", stderr.String()))

--- a/pkg/installer/providers/progress.go
+++ b/pkg/installer/providers/progress.go
@@ -1,0 +1,35 @@
+package providers
+
+import (
+	"context"
+	"io"
+)
+
+// progressWriterKey is the context key used to attach a progress writer to
+// an install/update call. Keeping it unexported prevents accidental key
+// collisions across packages.
+type progressWriterKey struct{}
+
+// WithProgressWriter returns a new context that carries the given writer.
+// Providers use it to tee the subprocess stdout/stderr while they run, so
+// callers can surface live output for long-running installs or updates.
+//
+// A nil or zero writer disables streaming (provider behaves as before).
+// Providers always still capture the full output into Result.Output, so
+// callers that ignore the stream lose no information.
+func WithProgressWriter(ctx context.Context, w io.Writer) context.Context {
+	if w == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, progressWriterKey{}, w)
+}
+
+// ProgressWriter returns the writer associated with the context, or
+// io.Discard if none was set. Callers should use the returned writer
+// unconditionally.
+func ProgressWriter(ctx context.Context) io.Writer {
+	if w, ok := ctx.Value(progressWriterKey{}).(io.Writer); ok && w != nil {
+		return w
+	}
+	return io.Discard
+}

--- a/pkg/installer/providers/progress_test.go
+++ b/pkg/installer/providers/progress_test.go
@@ -1,0 +1,53 @@
+package providers
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"testing"
+)
+
+func TestProgressWriter_DefaultIsDiscard(t *testing.T) {
+	w := ProgressWriter(context.Background())
+	if w == nil {
+		t.Fatal("ProgressWriter returned nil")
+	}
+	if w != io.Discard {
+		t.Errorf("ProgressWriter(empty ctx) = %T, want io.Discard", w)
+	}
+}
+
+func TestProgressWriter_RoundTrip(t *testing.T) {
+	var buf bytes.Buffer
+	ctx := WithProgressWriter(context.Background(), &buf)
+
+	w := ProgressWriter(ctx)
+	if w == nil {
+		t.Fatal("ProgressWriter returned nil after WithProgressWriter")
+	}
+
+	const want = "hello streaming world"
+	if _, err := w.Write([]byte(want)); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if got := buf.String(); got != want {
+		t.Errorf("round-trip: got %q, want %q", got, want)
+	}
+}
+
+func TestWithProgressWriter_NilIsNoop(t *testing.T) {
+	// Attaching a nil writer should leave the context unchanged so that
+	// callers passing a zero writer don't accidentally silence a previously
+	// attached one.
+	var buf bytes.Buffer
+	ctx := WithProgressWriter(context.Background(), &buf)
+	ctx = WithProgressWriter(ctx, nil)
+
+	w := ProgressWriter(ctx)
+	if _, err := w.Write([]byte("x")); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if buf.String() != "x" {
+		t.Errorf("nil re-assignment clobbered prior writer: got %q", buf.String())
+	}
+}


### PR DESCRIPTION
## Summary

Addresses the \"sits silent for minutes\" UX when `agent install` or `agent update` runs a long-lived subprocess (`brew upgrade`, `npm install -g` of a large package, `uv tool install`, etc.). Opt-in via the existing `-v/--verbose` flag so default output stays compact.

## Changes

### Provider layer
- New `pkg/installer/providers/progress.go`: `WithProgressWriter(ctx, io.Writer)` attaches a writer to a context; `ProgressWriter(ctx)` reads it back (`io.Discard` if unset). Keeps the knob decoupled from every provider's signature.
- `npm`, `brew`, `pip`, and `native` providers: Install + Update now tee subprocess stdout/stderr through the context writer via `io.MultiWriter`. `Result.Output` (full captured output) is preserved exactly, so non-streaming callers see no change.

### CLI layer
- `verboseInstallOutput(cfg)` checks the root-level `-v/--verbose` flag (the root command already maps it to `cfg.Logging.Level=\"debug\"`).
- `withInstallProgress(ctx, cfg)` attaches `os.Stderr` as the writer when enabled.
- `agent install`, `agent update` (single), `agent update --all`: when `-v` is on, we suppress the rolling spinner (ANSI would garble the interleaved output) and print plain headers followed by the live subprocess output, then a summary line.
- Default behavior (no `-v`) is unchanged.

## Demo

```
# before — no output for 30+s during a big brew upgrade
$ agentmgr agent update aider
⠙ Updating aider via brew...
✓ Updated aider to 0.86.2

# after — with -v, live brew output:
$ agentmgr agent update -v aider
Updating aider via brew...
==> Fetching aider
==> Downloading https://...
######################################################################## 100.0%
==> Pouring aider-0.86.2.arm64_sequoia.bottle.tar.gz
🍺  /opt/homebrew/Cellar/aider/0.86.2: 234 files, 17.6MB
Updated aider to 0.86.2
```

## Tests

- `pkg/installer/providers/progress_test.go`: round-trip, default-discard, and nil-writer-is-noop invariants.

## Test plan

- [ ] `go build ./...` clean
- [ ] `go test ./... -race -short` green
- [ ] `make lint` clean (v1.64.8)
- [ ] Manual: `agentmgr agent install -v codex` streams npm output
- [ ] Manual: `agentmgr agent update -v --all` streams per-agent output
- [ ] Manual: default `agentmgr agent update --all` unchanged (spinner only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)