### PR TITLE
feat(helper): start gRPC server when API.EnableGRPC is true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Systray helper now starts the gRPC API server when `API.EnableGRPC=true`
+  (default off, matching REST).
+
 ### Removed
 
 - `config.CatalogConfig.RefreshOnStart` field removed. Deprecated in

--- a/internal/systray/systray.go
+++ b/internal/systray/systray.go
@@ -17,6 +17,7 @@ import (
 	"github.com/kevinelliott/agentmanager/internal/orchestrator"
 	"github.com/kevinelliott/agentmanager/internal/versionfetch"
 	"github.com/kevinelliott/agentmanager/pkg/agent"
+	grpcapi "github.com/kevinelliott/agentmanager/pkg/api/grpc"
 	"github.com/kevinelliott/agentmanager/pkg/api/rest"
 	"github.com/kevinelliott/agentmanager/pkg/catalog"
 	"github.com/kevinelliott/agentmanager/pkg/config"
@@ -55,6 +56,9 @@ type App struct {
 
 	// REST API server (optional)
 	restServer *rest.Server
+
+	// gRPC API server (optional)
+	grpcServer *grpcapi.Server
 
 	// State
 	agents      []agent.Installation
@@ -135,6 +139,13 @@ func (a *App) Run() error {
 		}
 	}
 
+	// Start gRPC API server if enabled
+	if a.config.API.EnableGRPC {
+		if err := a.startGRPCServer(); err != nil {
+			return fmt.Errorf("failed to start gRPC server: %w", err)
+		}
+	}
+
 	// Run systray (blocks until quit)
 	// On macOS, this must run on the main thread
 	systray.Run(a.onReady, a.onExit)
@@ -155,6 +166,18 @@ func (a *App) startRESTServer() error {
 	)
 	return a.restServer.Start(a.ctx, rest.ServerConfig{
 		Address: fmt.Sprintf(":%d", a.config.API.RESTPort),
+	})
+}
+
+// startGRPCServer starts the gRPC API server.
+func (a *App) startGRPCServer() error {
+	a.grpcServer = grpcapi.NewServer(
+		a.config, a.platform, a.store, a.detector, a.catalog, a.installer,
+		grpcapi.WithVersion(a.version),
+		grpcapi.WithStartTime(a.startTime),
+	)
+	return a.grpcServer.Start(a.ctx, grpcapi.ServerConfig{
+		Address: fmt.Sprintf(":%d", a.config.API.GRPCPort),
 	})
 }
 
@@ -390,6 +413,24 @@ func (a *App) onExit() {
 	// Stop REST server
 	if a.restServer != nil {
 		a.restServer.Stop(ctx)
+	}
+
+	// Stop gRPC server: prefer GracefulStop with a short timeout; fall back
+	// to a hard Stop if graceful shutdown does not complete in time so a
+	// wedged in-flight RPC cannot block helper exit.
+	if a.grpcServer != nil {
+		graceCtx, graceCancel := context.WithTimeout(context.Background(), 2*time.Second)
+		gracefulDone := make(chan struct{})
+		go func() {
+			_ = a.grpcServer.Stop(graceCtx)
+			close(gracefulDone)
+		}()
+		select {
+		case <-gracefulDone:
+		case <-graceCtx.Done():
+			a.grpcServer.ForceStop()
+		}
+		graceCancel()
 	}
 
 	// Stop IPC server (drains in-flight handlers before returning).

--- a/internal/systray/systray_test.go
+++ b/internal/systray/systray_test.go
@@ -2,7 +2,11 @@ package systray
 
 import (
 	"bytes"
+	"context"
 	"testing"
+	"time"
+
+	"github.com/kevinelliott/agentmanager/pkg/config"
 )
 
 func TestGetIcon(t *testing.T) {
@@ -33,5 +37,52 @@ func TestGetIconConsistency(t *testing.T) {
 
 	if !bytes.Equal(icon1, icon2) {
 		t.Error("getIcon() should return consistent results")
+	}
+}
+
+// TestStartGRPCServerPopulatesField verifies that startGRPCServer wires up
+// the gRPC server on App when invoked (which is what Run() does when
+// API.EnableGRPC is true). Uses port :0 to avoid binding to a fixed port.
+// Also confirms that the server is nil if startGRPCServer is never called,
+// matching the EnableGRPC=false default path.
+func TestStartGRPCServerPopulatesField(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	a := &App{
+		config: &config.Config{
+			API: config.APIConfig{
+				EnableGRPC: true,
+				GRPCPort:   0, // bind ephemeral port for test isolation
+			},
+		},
+		ctx:       ctx,
+		startTime: time.Now(),
+		version:   "test",
+	}
+
+	// Default path: server should be nil when not started.
+	if a.grpcServer != nil {
+		t.Fatal("grpcServer should be nil before startGRPCServer() runs")
+	}
+
+	if err := a.startGRPCServer(); err != nil {
+		t.Fatalf("startGRPCServer() error = %v", err)
+	}
+	defer func() {
+		if a.grpcServer != nil {
+			_ = a.grpcServer.Stop(context.Background())
+		}
+	}()
+
+	if a.grpcServer == nil {
+		t.Fatal("startGRPCServer() did not populate App.grpcServer")
+	}
+
+	// Give the goroutine inside Start() a moment to register the listener,
+	// then verify it has a bound address (proves Serve is actually running).
+	time.Sleep(20 * time.Millisecond)
+	if addr := a.grpcServer.Address(); addr == "" {
+		t.Error("grpc server Address() should be non-empty after Start()")
 	}
 }

--- a/pkg/api/grpc/server.go
+++ b/pkg/api/grpc/server.go
@@ -197,6 +197,18 @@ func (s *Server) Stop(ctx context.Context) error {
 	return nil
 }
 
+// ForceStop immediately stops the gRPC server without waiting for in-flight
+// RPCs to complete. Intended as a fallback when a bounded GracefulStop does
+// not return in time (e.g. a wedged streaming handler during helper exit).
+func (s *Server) ForceStop() {
+	if s.grpcServer != nil {
+		s.grpcServer.Stop()
+	}
+	if s.listener != nil {
+		s.listener.Close()
+	}
+}
+
 // Address returns the server's listening address.
 func (s *Server) Address() string {
 	if s.listener != nil {


### PR DESCRIPTION
## Summary

The systray helper previously only started the REST API when `API.EnableREST` was set; the matching `API.EnableGRPC` config flag was silently ignored. This PR wires the gRPC server (already hardened in v1.1.0 with keepalive, message-size limits, and panic-recovery interceptors) into the helper startup/shutdown path, mirroring the REST pattern.

- **Default remains OFF** — no behavior change for existing users.
- **Port defaults to 50051** (per `pkg/config/config.go`).
- **Both REST and gRPC can run concurrently** — independent if-blocks in `Run()` on distinct ports.

## Changes

- `internal/systray/systray.go`:
  - New `grpcServer *grpcapi.Server` field (internal grpc pkg aliased as `grpcapi` to avoid shadowing `google.golang.org/grpc`).
  - New `startGRPCServer()` mirroring `startRESTServer()`, using `WithVersion(a.version)` and `WithStartTime(a.startTime)`.
  - `Run()` starts the gRPC server when `a.config.API.EnableGRPC` is true.
  - Shutdown path runs `GracefulStop` bounded by a 2s timeout, falling back to a hard `ForceStop` so a wedged streaming RPC cannot block helper exit.
- `pkg/api/grpc/server.go`:
  - Add `ForceStop()` for the hard-stop fallback used by the systray shutdown path.
- `internal/systray/systray_test.go`:
  - New `TestStartGRPCServerPopulatesField` verifies `startGRPCServer()` populates `App.grpcServer` and the listener binds (ephemeral `:0` port for test isolation).
- `CHANGELOG.md` — `[Unreleased] > Added` entry.

## Test plan

- [x] `go build ./...` clean on darwin
- [x] `go test ./internal/systray/... ./pkg/api/grpc/... ./pkg/api/rest/... -race -count=1` green
- [x] `/tmp/gcil-install/golangci-lint run --timeout=5m` clean
- [ ] Manual smoke: set `api.enable_grpc: true` in config, launch helper, run `grpcurl -plaintext localhost:50051 list` (reflection is registered by the server)
- [ ] Manual smoke: leave default config, launch helper, confirm nothing binds to 50051 (default OFF preserved)

Diff stat: 4 files changed, 109 insertions(+).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>