### PR TITLE
chore(config): remove deprecated Catalog.RefreshOnStart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- `config.CatalogConfig.RefreshOnStart` field removed. Deprecated in
+  v1.1.0 and never wired to any startup behavior — catalog refresh
+  cadence is controlled by `RefreshInterval` + the manager's cache
+  TTL. Existing configs that still set `catalog.refresh_on_start`
+  will continue to load without error (viper ignores unknown keys);
+  the value is simply dropped.
+
 ## [1.1.0] - 2026-04-21
 
 Performance, reliability, and refactor release. Typical `agent list`
@@ -92,7 +101,7 @@ consolidated detect pipeline. Ships a critical gRPC CVE fix.
   cadence is controlled by `RefreshInterval` + cache TTL). It is
   retained for backward compatibility with existing config files
   and will be removed once the sole remaining TUI display reference
-  is cleaned up.
+  is cleaned up. (Removed in [Unreleased].)
 
 ### Known Issues
 

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -366,8 +366,8 @@ func TestParseConfigValue(t *testing.T) {
 		expected interface{}
 	}{
 		// Boolean keys
-		{"bool true lowercase", "catalog.refresh_on_start", "true", true},
-		{"bool true uppercase", "catalog.refresh_on_start", "TRUE", true},
+		{"bool true lowercase", "updates.auto_check", "true", true},
+		{"bool true uppercase", "updates.auto_check", "TRUE", true},
 		{"bool true yes", "updates.auto_check", "yes", true},
 		{"bool true 1", "updates.notify", "1", true},
 		{"bool false lowercase", "updates.auto_update", "false", false},
@@ -398,7 +398,7 @@ func TestParseConfigValue(t *testing.T) {
 		{"string with spaces", "some.key", "value with spaces", "value with spaces"},
 
 		// Case insensitive keys
-		{"case insensitive bool", "CATALOG.REFRESH_ON_START", "true", true},
+		{"case insensitive bool", "UPDATES.AUTO_CHECK", "true", true},
 		{"case insensitive int", "UI.PAGE_SIZE", "25", 25},
 		{"case insensitive duration", "CATALOG.REFRESH_INTERVAL", "2h", 2 * time.Hour},
 	}
@@ -416,7 +416,6 @@ func TestParseConfigValue(t *testing.T) {
 
 func TestParseConfigValueAllBoolKeys(t *testing.T) {
 	boolKeys := []string{
-		"catalog.refresh_on_start",
 		"updates.auto_check",
 		"updates.notify",
 		"updates.auto_update",

--- a/internal/cli/config_cmd.go
+++ b/internal/cli/config_cmd.go
@@ -137,7 +137,6 @@ func parseConfigValue(key, value string) interface{} {
 
 	// Boolean keys
 	boolKeys := []string{
-		"catalog.refresh_on_start",
 		"updates.auto_check", "updates.notify", "updates.auto_update",
 		"ui.show_hidden", "ui.use_colors", "ui.compact_mode",
 		"api.enable_grpc", "api.enable_rest", "api.require_auth",

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -578,18 +578,11 @@ func (m Model) settingsView() string {
 	settings := styles.Box.Render(fmt.Sprintf(
 		"%s\n\n"+
 			"  Auto-check updates:    %s\n"+
-			"  Catalog auto-refresh:  %s\n"+
 			"  Notifications:         %s\n"+
 			"  Auto-update:           %s",
 		styles.Subtitle.Render("Update Settings"),
 		func() string {
 			if m.config.Updates.AutoCheck {
-				return styles.StatusInstalled.Render("Enabled")
-			}
-			return styles.StatusNotInstalled.Render("Disabled")
-		}(),
-		func() string {
-			if m.config.Catalog.RefreshOnStart { //nolint:staticcheck // deprecated: retained for backward-compat display
 				return styles.StatusInstalled.Render("Enabled")
 			}
 			return styles.StatusNotInstalled.Render("Disabled")

--- a/pkg/catalog/manager_test.go
+++ b/pkg/catalog/manager_test.go
@@ -92,7 +92,6 @@ func newTestConfig() *config.Config {
 		Catalog: config.CatalogConfig{
 			SourceURL:       "http://example.com/catalog.json",
 			RefreshInterval: time.Hour,
-			RefreshOnStart:  true,
 		},
 	}
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -52,16 +52,6 @@ type CatalogConfig struct {
 	// RefreshInterval is how often to refresh in background
 	RefreshInterval time.Duration `yaml:"refresh_interval" json:"refresh_interval" mapstructure:"refresh_interval"`
 
-	// RefreshOnStart enables auto-refresh when the app starts.
-	//
-	// Deprecated: this field is not currently wired to any startup behavior
-	// and is retained only for backward compatibility with existing config
-	// files (reading a YAML config that sets it will not error). The catalog
-	// refresh cadence is controlled by RefreshInterval and the manager's
-	// cache TTL. Do not rely on this flag in new code — it is scheduled for
-	// removal once the TUI display reference is cleaned up.
-	RefreshOnStart bool `yaml:"refresh_on_start" json:"refresh_on_start" mapstructure:"refresh_on_start"`
-
 	// GitHubToken is an optional token for higher API rate limits
 	GitHubToken string `yaml:"github_token" json:"github_token" mapstructure:"github_token"`
 }
@@ -180,7 +170,6 @@ func Default() *Config {
 		Catalog: CatalogConfig{
 			SourceURL:       "https://raw.githubusercontent.com/kevinelliott/agentmanager/main/catalog.json",
 			RefreshInterval: time.Hour,
-			RefreshOnStart:  true,
 			GitHubToken:     "",
 		},
 		Detection: DetectionConfig{

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -15,9 +15,6 @@ func TestDefault(t *testing.T) {
 	if cfg.Catalog.RefreshInterval != time.Hour {
 		t.Errorf("Catalog.RefreshInterval = %v, want %v", cfg.Catalog.RefreshInterval, time.Hour)
 	}
-	if !cfg.Catalog.RefreshOnStart {
-		t.Error("Catalog.RefreshOnStart should be true")
-	}
 
 	// Test update defaults
 	if !cfg.Updates.AutoCheck {
@@ -379,7 +376,6 @@ func TestCatalogConfig(t *testing.T) {
 	cfg := CatalogConfig{
 		SourceURL:       "https://example.com/catalog.json",
 		RefreshInterval: 2 * time.Hour,
-		RefreshOnStart:  false,
 		GitHubToken:     "test-token",
 	}
 
@@ -388,9 +384,6 @@ func TestCatalogConfig(t *testing.T) {
 	}
 	if cfg.RefreshInterval != 2*time.Hour {
 		t.Errorf("RefreshInterval = %v, want %v", cfg.RefreshInterval, 2*time.Hour)
-	}
-	if cfg.RefreshOnStart {
-		t.Error("RefreshOnStart should be false")
 	}
 	if cfg.GitHubToken != "test-token" {
 		t.Errorf("GitHubToken = %q, want %q", cfg.GitHubToken, "test-token")

--- a/pkg/config/loader.go
+++ b/pkg/config/loader.go
@@ -161,7 +161,6 @@ func (l *Loader) setDefaults() {
 	// Catalog defaults
 	l.v.SetDefault("catalog.source_url", defaults.Catalog.SourceURL)
 	l.v.SetDefault("catalog.refresh_interval", defaults.Catalog.RefreshInterval)
-	l.v.SetDefault("catalog.refresh_on_start", defaults.Catalog.RefreshOnStart)
 	l.v.SetDefault("catalog.github_token", defaults.Catalog.GitHubToken)
 
 	// Update defaults

--- a/pkg/config/loader_test.go
+++ b/pkg/config/loader_test.go
@@ -62,7 +62,6 @@ func TestLoaderLoadFromFile(t *testing.T) {
 	configContent := `
 catalog:
   source_url: "https://custom.example.com/catalog.json"
-  refresh_on_start: false
 ui:
   theme: "dark"
   page_size: 50
@@ -87,9 +86,6 @@ logging:
 	// Verify loaded values
 	if cfg.Catalog.SourceURL != "https://custom.example.com/catalog.json" {
 		t.Errorf("SourceURL = %q, want %q", cfg.Catalog.SourceURL, "https://custom.example.com/catalog.json")
-	}
-	if cfg.Catalog.RefreshOnStart {
-		t.Error("RefreshOnStart should be false")
 	}
 	if cfg.UI.Theme != "dark" {
 		t.Errorf("Theme = %q, want %q", cfg.UI.Theme, "dark")


### PR DESCRIPTION
## Summary

- Removes the `RefreshOnStart` field from `config.CatalogConfig` and all its consumers. The flag was never wired to any startup behavior since introduction; catalog refresh cadence is controlled by `RefreshInterval` + the manager's cache TTL.
- Deprecated in v1.1.0 with a comment noting it would be removed "once the TUI display reference is cleaned up" — this PR finishes that cleanup.
- Drops the viper default (`catalog.refresh_on_start`), the "Catalog auto-refresh" row in the TUI settings panel, the key's listing in the CLI `config set` bool-key table, and all test references.

## Compatibility

- Existing user configs that still set `catalog.refresh_on_start` continue to load cleanly. Viper silently ignores unknown keys, so the value is simply dropped on load — no migration warning is added (it would be cosmetic; the key was never actually wired).

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./... -race -short -count=1` green
- [x] `/tmp/gcil-install/golangci-lint run --timeout=5m` clean (v1.64.8)
- [x] `gofmt -l` clean
- [x] `goimports -l -local github.com/kevinelliott/agentmanager` clean
- [x] Manually re-grep confirms no `RefreshOnStart` / `refresh_on_start` references remain outside CHANGELOG context

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>