### PR TITLE
feat(catalog): route cache-save warning through ctx-scoped logger

### DIFF
--- a/pkg/catalog/manager.go
+++ b/pkg/catalog/manager.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/kevinelliott/agentmanager/pkg/agent"
 	"github.com/kevinelliott/agentmanager/pkg/config"
+	"github.com/kevinelliott/agentmanager/pkg/logging"
 	"github.com/kevinelliott/agentmanager/pkg/storage"
 )
 
@@ -167,8 +168,10 @@ func (m *Manager) doRefresh(ctx context.Context) (*RefreshResult, error) {
 		etagToStore = remoteCatalog.Version
 	}
 	if err := m.store.SaveCatalogCache(ctx, mustMarshal(remoteCatalog), etagToStore); err != nil {
-		// Non-fatal: we still have the catalog in memory.
-		slog.Warn("catalog: failed to persist cache",
+		// Non-fatal: we still have the catalog in memory. Use the
+		// request-scoped logger so operators can tag refresh events
+		// (e.g. with a trigger source) at the call site.
+		logging.FromContext(ctx).Warn("catalog: failed to persist cache",
 			"err", err,
 			"version", remoteCatalog.Version,
 		)

--- a/pkg/catalog/manager_test.go
+++ b/pkg/catalog/manager_test.go
@@ -1,12 +1,15 @@
 package catalog
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -14,6 +17,7 @@ import (
 
 	"github.com/kevinelliott/agentmanager/pkg/agent"
 	"github.com/kevinelliott/agentmanager/pkg/config"
+	"github.com/kevinelliott/agentmanager/pkg/logging"
 	"github.com/kevinelliott/agentmanager/pkg/storage"
 )
 
@@ -717,7 +721,8 @@ func TestManagerRefresh_SendsIfNoneMatchAndHandles304(t *testing.T) {
 
 // TestManagerRefresh_LogsCacheSaveErrorButSucceeds verifies that a failing
 // SaveCatalogCache does not fail the whole Refresh — the in-memory catalog
-// should still be updated and the caller should get a success result.
+// should still be updated and the caller should get a success result, and
+// that the cache-save failure is reported via the context-scoped logger.
 func TestManagerRefresh_LogsCacheSaveErrorButSucceeds(t *testing.T) {
 	withEmbeddedJSON(t, nil)
 
@@ -736,7 +741,12 @@ func TestManagerRefresh_LogsCacheSaveErrorButSucceeds(t *testing.T) {
 	store := &mockStore{err: os.ErrPermission}
 	mgr := NewManager(cfg, store)
 
-	ctx := context.Background()
+	// Attach a test logger so we can assert the warn event fires on the
+	// ctx-scoped logger (not just slog.Default).
+	var logBuf bytes.Buffer
+	testLogger := slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	ctx := logging.WithContext(context.Background(), testLogger)
+
 	result, err := mgr.Refresh(ctx)
 	if err != nil {
 		t.Fatalf("Refresh() should succeed despite cache write error, got %v", err)
@@ -752,5 +762,13 @@ func TestManagerRefresh_LogsCacheSaveErrorButSucceeds(t *testing.T) {
 	}
 	if got.Version != catalog.Version {
 		t.Errorf("in-memory catalog version = %q, want %q", got.Version, catalog.Version)
+	}
+
+	// The warn event should have gone to the ctx-scoped logger.
+	if !strings.Contains(logBuf.String(), "catalog: failed to persist cache") {
+		t.Errorf("ctx-scoped logger did not receive the warn event:\n%s", logBuf.String())
+	}
+	if !strings.Contains(logBuf.String(), "level=WARN") {
+		t.Errorf("ctx-scoped log entry should be WARN level:\n%s", logBuf.String())
 	}
 }


### PR DESCRIPTION
## Summary

\`doRefresh\` now emits its cache-save warn via \`logging.FromContext(ctx).Warn(...)\` instead of the package-level \`slog.Warn\`. This lets callers:

- Attach a request-scoped logger via \`logging.WithContext\` to tag events with trigger source.
- Correlate cache-save failures with an outer request or background tick.
- Inject a test logger to assert events fired (as the updated test now does).

## Behavior in production

Unchanged. Without an attached logger, \`FromContext\` falls back to \`slog.Default\`, which \`logging.Install(logging.New(cfg))\` in each \`main\` has already pointed at the configured handler.

## Test

\`TestManagerRefresh_LogsCacheSaveErrorButSucceeds\` now attaches a test logger via \`logging.WithContext\` and asserts the warn event reaches it — previously we only tested that the cache-error path didn't fail the refresh.

## Not changed

\`mustMarshal\`'s \`slog.Warn\` is untouched: its signature has no ctx and that path is a should-never-fire marshal of a struct we control.

## Test plan

- [ ] \`go test ./pkg/catalog/... -race\` green
- [ ] \`make lint\` clean
- [ ] \`go test ./... -race -short\` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)