### PR TITLE
fix: address Copilot review feedback — correctness fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -225,7 +225,7 @@ consolidated detect pipeline. Ships a critical gRPC CVE fix.
   cadence is controlled by `RefreshInterval` + cache TTL). It is
   retained for backward compatibility with existing config files
   and will be removed once the sole remaining TUI display reference
-  is cleaned up. (Removed in [Unreleased].)
+  is cleaned up. (Removed in v1.2.0.)
 
 ### Known Issues
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A comprehensive CLI/TUI/Library application for detecting, managing, installing,
 - **Version Management**: Check for updates from package registries (npm, PyPI, Homebrew) and manage agent versions
 - **Multiple Installation Methods**: Support for npm, pip, pipx, uv, Homebrew, native installers, and more
 - **Fast Parallel Checks**: Version checks for dozens of installed agents run concurrently (10–20× faster than sequential)
-- **Offline-First Catalog**: A baseline catalog is embedded into the binary, so `agent list` works on a fresh `go install` before the first remote refresh
+- **Offline-First Catalog**: A baseline catalog is embedded into the binary, so `agentmgr agent list` works on a fresh `go install` before the first remote refresh
 - **Live Install Output**: Pass `-v` to `agent install` / `agent update` to stream live subprocess output (brew / npm / pip / native) instead of a silent spinner
 - **Beautiful CLI Output**: Colored output with animated spinners and properly aligned tables (honors `NO_COLOR`, `TERM=dumb`, and non-TTY pipes)
 - **Beautiful TUI**: Interactive terminal interface built with Bubble Tea

--- a/internal/cli/agent.go
+++ b/internal/cli/agent.go
@@ -70,13 +70,11 @@ detailed information about agents.`,
 
 func newAgentListCommand(cfg *config.Config) *cobra.Command {
 	var (
-		showAll      bool
-		showHidden   bool
-		format       string
-		updatesOnly  bool
-		checkUpdates bool
-		refresh      bool
-		verify       bool
+		showHidden  bool
+		format      string
+		updatesOnly bool
+		refresh     bool
+		verify      bool
 	)
 
 	cmd := &cobra.Command{
@@ -214,11 +212,9 @@ Results are cached for 1 hour by default. Use --refresh to force re-detection.`,
 		},
 	}
 
-	cmd.Flags().BoolVarP(&showAll, "all", "a", false, "show all installations")
 	cmd.Flags().BoolVar(&showHidden, "hidden", false, "show hidden agents")
 	cmd.Flags().StringVarP(&format, "format", "f", "table", "output format (table, json)")
 	cmd.Flags().BoolVarP(&updatesOnly, "updates", "u", false, "show only agents with updates")
-	cmd.Flags().BoolVar(&checkUpdates, "check-updates", false, "check for available updates")
 	cmd.Flags().BoolVarP(&refresh, "refresh", "r", false, "force re-detection (ignore cache)")
 	cmd.Flags().BoolVar(&verify, "verify", false, "verify agents can execute (health check)")
 

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -112,11 +112,17 @@ func TestNewAgentCommand(t *testing.T) {
 	// Verify list subcommand has expected flags
 	listCmd := findSubcommand(cmd, "list")
 	if listCmd != nil {
-		assertFlagExists(t, listCmd, "all")
 		assertFlagExists(t, listCmd, "hidden")
 		assertFlagExists(t, listCmd, "format")
 		assertFlagExists(t, listCmd, "updates")
 		assertFlagExists(t, listCmd, "refresh")
+		// Removed: "all" and "check-updates" — both bound to unused local
+		// vars (silent no-ops). Assert their absence to prevent reintro.
+		for _, removed := range []string{"all", "check-updates"} {
+			if listCmd.Flags().Lookup(removed) != nil {
+				t.Errorf("flag %q should have been removed from list command", removed)
+			}
+		}
 
 		// Check alias
 		if len(listCmd.Aliases) == 0 || listCmd.Aliases[0] != "ls" {

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -460,7 +460,8 @@ func runConfigChecks(cfg *config.Config, _ bool) []CheckResult {
 // Sources, in resolution order:
 //  1. SQLite cache (the last remote fetch)
 //  2. User overrides ($HOME/.agentmgr/catalog.json, $HOME/.config/agentmgr/catalog.json)
-//  3. System-wide install share (/usr/local/share/agentmgr, /etc/agentmgr)
+//  3. System-wide install share (/usr/share/agentmgr for .deb/.rpm,
+//     /usr/local/share/agentmgr for manual installs, /etc/agentmgr)
 //  4. Embedded baseline (//go:embed'd into the binary)
 //
 // The CWD is intentionally never probed.
@@ -524,7 +525,8 @@ func runCatalogSourceChecks(ctx context.Context, cfg *config.Config, _ bool) []C
 		)
 	}
 	paths = append(paths,
-		struct{ label, path string }{"System share", "/usr/local/share/agentmgr/catalog.json"},
+		struct{ label, path string }{"System share (.deb/.rpm)", "/usr/share/agentmgr/catalog.json"},
+		struct{ label, path string }{"System share (/usr/local)", "/usr/local/share/agentmgr/catalog.json"},
 		struct{ label, path string }{"System etc", "/etc/agentmgr/catalog.json"},
 	)
 

--- a/internal/cli/output/spinner_test.go
+++ b/internal/cli/output/spinner_test.go
@@ -25,9 +25,13 @@ func TestSpinner_NonTTY_StartIsNoop(t *testing.T) {
 		WithInterval(5*time.Millisecond),
 	)
 	s.Start()
-	// Give the goroutine a chance to emit frames — there should be NONE
-	// because Start is a no-op on non-TTY output.
-	time.Sleep(30 * time.Millisecond)
+	// Start() is a no-op on non-TTY output: no goroutine is spawned and
+	// no frames are written. We don't need to wait — if Start had spawned
+	// anything, s.isTTY would be true here and the structure of the test
+	// fails fast rather than relying on sleep-based timing.
+	if s.isTTY {
+		t.Fatalf("isTTY = true for bytes.Buffer output; non-TTY path not exercised")
+	}
 	s.Stop()
 
 	if got := buf.String(); got != "" {

--- a/internal/cli/output/table_test.go
+++ b/internal/cli/output/table_test.go
@@ -52,14 +52,16 @@ func TestTable_RenderBasic(t *testing.T) {
 	}
 
 	// Column count: each non-empty line should contain both columns.
+	// Every non-empty row should contain both columns on the same line —
+	// the shorter row should still have spaces between its first cell and
+	// the second column, proving the padding pass ran.
 	for _, line := range strings.Split(strings.TrimSpace(out), "\n") {
 		if line == "" {
 			continue
 		}
-		// Rough alignment sanity: the longest row (claude-code = 11 chars)
-		// should leave at least padding+1 spaces before the second column
-		// for shorter rows.
-		_ = line
+		if !strings.Contains(line, "  ") {
+			t.Errorf("line %q lacks inter-column padding", line)
+		}
 	}
 }
 

--- a/internal/systray/cli_uninstall_darwin.go
+++ b/internal/systray/cli_uninstall_darwin.go
@@ -4,54 +4,30 @@ package systray
 
 import (
 	"fmt"
-	"os"
 	"os/exec"
-	"path/filepath"
-
-	"github.com/kevinelliott/agentmanager/pkg/platform"
 )
 
-// uninstallCLI removes the CLI binary from the system path.
+// uninstallCLI removes the CLI binary from the system path on darwin.
 //
-// Only invoked by the darwin systray menu; other platforms have no caller and
-// the function is omitted from their builds via the build tag on this file.
+// Only invoked by the darwin systray menu. The function is omitted from
+// non-darwin builds via the build tag on this file, so platform.ID() is
+// always platform.Darwin at runtime — no need to branch on it.
 func (a *App) uninstallCLI() bool {
-	targetPath := "/usr/local/bin/agentmgr"
+	const targetPath = "/usr/local/bin/agentmgr"
 
-	switch a.platform.ID() {
-	case platform.Darwin, platform.Linux:
-		// Use osascript to run sudo with password prompt
-		script := fmt.Sprintf(`
+	// Use osascript to run sudo with password prompt.
+	script := fmt.Sprintf(`
 do shell script "rm -f '%s'" with administrator privileges
 `, targetPath)
 
-		cmd := exec.Command("osascript", "-e", script)
-		err := cmd.Run()
-		if err != nil {
-			return false
-		}
-
-		// Clear config path
-		a.config.Helper.CLIPath = ""
-		if a.configLoader != nil {
-			_ = a.configLoader.SetAndSave("helper.cli_path", "")
-		}
-		return true
-
-	case platform.Windows:
-		// Try to remove directly on Windows
-		targetPath = filepath.Join(os.Getenv("LOCALAPPDATA"), "agentmgr", "agentmgr.exe")
-		if err := os.Remove(targetPath); err != nil {
-			return false
-		}
-
-		// Clear config path
-		a.config.Helper.CLIPath = ""
-		if a.configLoader != nil {
-			_ = a.configLoader.SetAndSave("helper.cli_path", "")
-		}
-		return true
+	if err := exec.Command("osascript", "-e", script).Run(); err != nil {
+		return false
 	}
 
-	return false
+	// Clear config path.
+	a.config.Helper.CLIPath = ""
+	if a.configLoader != nil {
+		_ = a.configLoader.SetAndSave("helper.cli_path", "")
+	}
+	return true
 }

--- a/internal/systray/handlers_test.go
+++ b/internal/systray/handlers_test.go
@@ -45,7 +45,13 @@ func mkInstallation(agentID, method, installedVer, latestVer string) agent.Insta
 }
 
 func mustParseVersion(v string) agent.Version {
-	out, _ := agent.ParseVersion(v)
+	out, err := agent.ParseVersion(v)
+	if err != nil {
+		// Test setup bug — surface loudly so the failing test points at
+		// the invalid fixture string rather than silently proceeding with
+		// a zero-value Version that makes downstream assertions confusing.
+		panic("mustParseVersion: " + v + ": " + err.Error())
+	}
 	return out
 }
 
@@ -273,9 +279,12 @@ func TestRequestShutdown_ConcurrentSafe(t *testing.T) {
 func TestDialogTracking(t *testing.T) {
 	a := mkTestApp()
 
-	// Track a couple of inert commands (we never call .Run()).
-	cmd1 := exec.Command("true")
-	cmd2 := exec.Command("true")
+	// trackDialog/untrackDialog only inspect pointer identity, so bare
+	// *exec.Cmd values are sufficient. Using exec.Command("true") would
+	// trigger a PATH lookup (no `true` on Windows CI) without improving
+	// the test.
+	cmd1 := &exec.Cmd{}
+	cmd2 := &exec.Cmd{}
 
 	a.trackDialog(cmd1)
 	a.trackDialog(cmd2)

--- a/pkg/api/grpc/server.go
+++ b/pkg/api/grpc/server.go
@@ -200,7 +200,7 @@ func (s *Server) Stop(ctx context.Context) error {
 		s.grpcServer.GracefulStop()
 	}
 	if s.listener != nil {
-		s.listener.Close()
+		_ = s.listener.Close() // teardown: close error is not actionable
 	}
 	return nil
 }
@@ -213,7 +213,7 @@ func (s *Server) ForceStop() {
 		s.grpcServer.Stop()
 	}
 	if s.listener != nil {
-		s.listener.Close()
+		_ = s.listener.Close() // teardown: close error is not actionable
 	}
 }
 

--- a/pkg/catalog/embed.go
+++ b/pkg/catalog/embed.go
@@ -15,8 +15,15 @@ import _ "embed"
 //go:embed catalog.json
 var embeddedCatalogJSON []byte
 
-// EmbeddedJSON returns the raw JSON bytes of the embedded catalog.
-// Callers that want a parsed *Catalog should use Manager.Get instead.
+// EmbeddedJSON returns a copy of the raw JSON bytes of the embedded
+// catalog. Callers that want a parsed *Catalog should use Manager.Get
+// instead.
+//
+// Returns a copy rather than the package-level slice directly — []byte
+// is mutable, so handing out the backing storage lets a caller (or
+// concurrent caller) accidentally scribble over the baseline.
 func EmbeddedJSON() []byte {
-	return embeddedCatalogJSON
+	out := make([]byte, len(embeddedCatalogJSON))
+	copy(out, embeddedCatalogJSON)
+	return out
 }

--- a/pkg/catalog/manager.go
+++ b/pkg/catalog/manager.go
@@ -91,7 +91,12 @@ type RefreshResult struct {
 // Returns a RefreshResult indicating whether an update occurred.
 //
 // Concurrent calls to Refresh coalesce via a singleflight group — only one
-// HTTP fetch runs at a time; other callers receive the same result.
+// HTTP fetch runs at a time; other callers receive the same result. Note
+// that singleflight does not merge contexts: whichever ctx the first
+// caller passed is the one used by the shared doRefresh. A caller with a
+// short deadline can therefore cancel the in-flight fetch for all shared
+// callers. This is acceptable because Refresh is not on any user-facing
+// critical path and the next caller will simply retry.
 func (m *Manager) Refresh(ctx context.Context) (*RefreshResult, error) {
 	v, err, _ := m.refreshGroup.Do("catalog-refresh", func() (interface{}, error) {
 		return m.doRefresh(ctx)

--- a/pkg/catalog/manager.go
+++ b/pkg/catalog/manager.go
@@ -317,8 +317,12 @@ func (m *Manager) loadEmbedded() (*Catalog, error) {
 		)
 	}
 
-	// 2. System-wide install share.
+	// 2. System-wide install share. `/usr/share/agentmgr/catalog.json` is
+	// where the goreleaser nfpm config installs the catalog for .deb/.rpm
+	// users; `/usr/local/share` is the common install prefix for manual
+	// installs; `/etc/agentmgr` is the system-wide override location.
 	paths = append(paths,
+		"/usr/share/agentmgr/catalog.json",
 		"/usr/local/share/agentmgr/catalog.json",
 		"/etc/agentmgr/catalog.json",
 	)

--- a/pkg/installer/providers/brew.go
+++ b/pkg/installer/providers/brew.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os/exec"
@@ -273,6 +274,15 @@ func (p *BrewProvider) GetLatestVersion(ctx context.Context, method catalog.Inst
 	}
 	once.Do(func() {
 		version, err := p.fetchLatestVersionUncached(ctx, packageName, isCask)
+		// Don't cache caller-specific context errors (canceled, deadline
+		// exceeded). A later caller with a healthy ctx would otherwise
+		// receive the first caller's transient failure for the full TTL.
+		// Leaving the cache empty and clearing the Once lets the next call
+		// refetch with its own ctx.
+		if err != nil && (errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)) {
+			brewLatestVersionOnce.Delete(key)
+			return
+		}
 		brewLatestVersionCache.Store(key, brewLatestEntry{
 			version:  version,
 			err:      err,

--- a/pkg/installer/providers/progress.go
+++ b/pkg/installer/providers/progress.go
@@ -17,7 +17,9 @@ type progressWriterKey struct{}
 //
 // Passing nil is a no-op: the returned context is the input context, so a
 // previously attached writer is NOT cleared. To actually silence streaming
-// after one was attached, start from a context that never had one.
+// after one was attached, start from a context that never had one. This
+// asymmetry lets middleware attach a writer safely without worrying about
+// downstream code accidentally clobbering it with nil.
 //
 // Providers always still capture the full output into Result.Output, so
 // callers that ignore the stream lose no information.

--- a/pkg/installer/providers/progress.go
+++ b/pkg/installer/providers/progress.go
@@ -3,6 +3,7 @@ package providers
 import (
 	"context"
 	"io"
+	"sync"
 )
 
 // progressWriterKey is the context key used to attach a progress writer to
@@ -14,14 +15,22 @@ type progressWriterKey struct{}
 // Providers use it to tee the subprocess stdout/stderr while they run, so
 // callers can surface live output for long-running installs or updates.
 //
-// A nil or zero writer disables streaming (provider behaves as before).
+// Passing nil is a no-op: the returned context is the input context, so a
+// previously attached writer is NOT cleared. To actually silence streaming
+// after one was attached, start from a context that never had one.
+//
 // Providers always still capture the full output into Result.Output, so
 // callers that ignore the stream lose no information.
+//
+// The returned writer is safe for concurrent calls to Write — providers
+// use it to tee BOTH cmd.Stdout and cmd.Stderr, which os/exec writes to
+// from separate goroutines. Internally Write calls serialize on a mutex
+// so concurrent writes produce non-interleaved byte sequences per call.
 func WithProgressWriter(ctx context.Context, w io.Writer) context.Context {
 	if w == nil {
 		return ctx
 	}
-	return context.WithValue(ctx, progressWriterKey{}, w)
+	return context.WithValue(ctx, progressWriterKey{}, &lockedWriter{w: w})
 }
 
 // ProgressWriter returns the writer associated with the context, or
@@ -32,4 +41,18 @@ func ProgressWriter(ctx context.Context) io.Writer {
 		return w
 	}
 	return io.Discard
+}
+
+// lockedWriter serializes concurrent Write calls so teeing a single
+// progress writer from cmd.Stdout and cmd.Stderr (os/exec writes those
+// from separate goroutines) doesn't interleave bytes mid-call.
+type lockedWriter struct {
+	mu sync.Mutex
+	w  io.Writer
+}
+
+func (l *lockedWriter) Write(p []byte) (int, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.w.Write(p)
 }

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -176,6 +176,14 @@ func cachedLookPath(name string) (string, error) {
 }
 
 // resetLookPathCache clears the memoization cache. Intended for tests.
+//
+// Uses Range+Delete rather than reassigning the package-level sync.Map —
+// struct assignment is not atomic with respect to concurrent readers, so
+// reassigning while cachedLookPath is running from another goroutine would
+// race on the zero value.
 func resetLookPathCache() {
-	lookPathCache = sync.Map{}
+	lookPathCache.Range(func(k, _ any) bool {
+		lookPathCache.Delete(k)
+		return true
+	})
 }


### PR DESCRIPTION
## Summary

Seven real-bug fixes called out across Copilot review comments on merged PRs (#19, #28, #29, #33) plus the dead-flag note on \`agent list\`.

## Fixes

| Site | Fix |
|---|---|
| \`pkg/platform/platform.go\` | \`resetLookPathCache()\` no longer reassigns the package-level \`sync.Map\` (unsafe vs concurrent readers). Uses \`Range\`+\`Delete\` instead. |
| \`pkg/installer/providers/brew.go\` | \`GetLatestVersion\` no longer caches ctx-canceled / deadline-exceeded errors. A caller with a short ctx previously poisoned the 5m TTL for every later caller. |
| \`pkg/installer/providers/progress.go\` | The progress writer is now wrapped in a locking writer so concurrent Writes from \`cmd.Stdout\` and \`cmd.Stderr\` (os/exec writes those from separate goroutines) don't interleave bytes mid-call. |
| \`pkg/catalog/embed.go\` | \`EmbeddedJSON()\` now returns a copy of the backing bytes. Callers could previously mutate the package-level \`[]byte\` and corrupt the baseline for every future \`Get()\`. |
| \`pkg/catalog/manager.go\` | \`loadEmbedded\` now also probes \`/usr/share/agentmgr/catalog.json\` — where the goreleaser nfpm config installs the catalog for .deb/.rpm users. Previously that path was silently ignored even though goreleaser wrote the file there at install time. |
| \`internal/cli/doctor.go\` | Catalog Sources section updated with the matching \`/usr/share/agentmgr\` row so \`doctor\` output mirrors the loader's probe order. |
| \`internal/cli/agent.go\` | Removed the \`--all\` / \`-a\` and \`--check-updates\` flags from \`agent list\`. Both bound to local vars that were never read anywhere — users setting them got a silent no-op. |

## Test plan

- [ ] \`go build ./...\` clean
- [ ] \`go test ./... -race -short\` green
- [ ] \`make lint\` clean (golangci-lint v2.11.4)
- [ ] \`agentmgr agent list\` still works; \`agentmgr agent list --all\` now rejects the unknown flag rather than silently no-op
- [ ] \`agentmgr doctor\` Catalog Sources section includes the new \`/usr/share/agentmgr\` row

🤖 Generated with [Claude Code](https://claude.com/claude-code)