### PR TITLE
fix(brew): also recognize legacy "cask: true" metadata key

### DIFF
--- a/pkg/installer/providers/brew.go
+++ b/pkg/installer/providers/brew.go
@@ -185,13 +185,20 @@ func (p *BrewProvider) Uninstall(ctx context.Context, inst *agent.Installation, 
 }
 
 // parseBrewPackage extracts the package name and determines if it's a cask.
+//
+// Cask is detected from method.Metadata using either of two keys:
+//   - "type": "cask"  — canonical form, used by current catalog entries
+//   - "cask": "true"  — legacy form, accepted for back-compat with custom
+//     user catalogs and historical catalog entries
+//
+// Falls back to parsing the command string if no package name is set.
 func (p *BrewProvider) parseBrewPackage(method catalog.InstallMethodDef) (string, bool) {
 	packageName := method.Package
 	isCask := false
 
-	// Check metadata for cask indicator
+	// Check metadata for cask indicator (both canonical and legacy forms).
 	if method.Metadata != nil {
-		if method.Metadata["type"] == "cask" {
+		if method.Metadata["type"] == "cask" || method.Metadata["cask"] == "true" {
 			isCask = true
 		}
 	}

--- a/pkg/installer/providers/providers_test.go
+++ b/pkg/installer/providers/providers_test.go
@@ -1028,13 +1028,45 @@ func TestBrewProviderParseBrewPackage(t *testing.T) {
 			wantIsCask: false,
 		},
 		{
-			name: "cask from metadata",
+			name: "cask from metadata (canonical type=cask)",
 			method: catalog.InstallMethodDef{
 				Package:  "visual-studio-code",
 				Metadata: map[string]string{"type": "cask"},
 			},
 			wantPkg:    "visual-studio-code",
 			wantIsCask: true,
+		},
+		{
+			// Some catalog entries (and user-customized catalogs) use the
+			// legacy form "cask: true" instead of "type: cask". Both should
+			// resolve to isCask=true so brew install gets the --cask flag.
+			name: "cask from metadata (legacy cask=true)",
+			method: catalog.InstallMethodDef{
+				Package:  "openclaw",
+				Metadata: map[string]string{"cask": "true"},
+			},
+			wantPkg:    "openclaw",
+			wantIsCask: true,
+		},
+		{
+			// type=cask wins regardless of cask= value.
+			name: "cask metadata both keys agree",
+			method: catalog.InstallMethodDef{
+				Package:  "firefox",
+				Metadata: map[string]string{"type": "cask", "cask": "true"},
+			},
+			wantPkg:    "firefox",
+			wantIsCask: true,
+		},
+		{
+			// Non-truthy cask value should NOT trigger cask handling.
+			name: "cask=false metadata not a cask",
+			method: catalog.InstallMethodDef{
+				Package:  "gh",
+				Metadata: map[string]string{"cask": "false"},
+			},
+			wantPkg:    "gh",
+			wantIsCask: false,
 		},
 		{
 			name: "extract from command",


### PR DESCRIPTION
## Summary

Five catalog entries (\`block-goose\`, \`openclaw\`, \`droid\`, \`claude-squad\`, \`amazon-q-cli\`) declare cask-ness via \`metadata.cask: "true"\` rather than the canonical \`metadata.type: "cask"\`. \`parseBrewPackage\` only checked the canonical key, so \`brew install\` ran without \`--cask\` for those agents and Homebrew rejected them as unknown formulae.

\`parseBrewPackage\` now accepts either form:

- \`"type": "cask"\` (canonical)
- \`"cask": "true"\` (legacy, also common in user-customized catalogs)

## Why no catalog edits

\`brew install/upgrade/uninstall\` already build their own arg lists from \`isCask\` — the \`command\`/\`update_cmd\`/\`uninstall_cmd\` strings in the catalog are documentation only. With the parser fix, all five existing entries Just Work; bumping the catalog version to canonicalize would force a refresh round-trip without changing behavior.

## Tests

\`TestBrewProviderParseBrewPackage\` extended with three new cases:
- \`cask from metadata (legacy cask=true)\`
- \`cask metadata both keys agree\` (canonical wins, no false-negative)
- \`cask=false metadata not a cask\` (truthy check is strict)

## Closes

Copilot review comment on PR #28 (catalog.json:707).

🤖 Generated with [Claude Code](https://claude.com/claude-code)